### PR TITLE
fix: Use apt-get clean over apt-get autoclean

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,10 @@ RUN apt-get update -y && \
         libxml2-dev \
         libxmlsec1-dev \
         libffi-dev \
-        liblzma-dev && \
-    apt-get install -y \
-        git \
+        liblzma-dev \
         g++ && \
+    apt-get install -y \
+        git && \
     apt-get -y clean && \
     apt-get -y autoremove && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update -y && \
     apt-get install -y \
         git \
         g++ && \
-    apt-get -y autoclean && \
+    apt-get -y clean && \
     apt-get -y autoremove && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
As covered in [`apt-get`'s `man` page](https://linux.die.net/man/8/apt-get)

```
       clean
           clean clears out the local repository of retrieved package files. It removes everything but the lock file from /var/cache/apt/archives/ and /var/cache/apt/archives/partial/.

       autoclean (and the auto-clean alias since 1.1)
           Like clean, autoclean clears out the local repository of retrieved package files. The difference is that it only removes package files that can no longer be downloaded, and are largely
           useless. This allows a cache to be maintained over a long period without it growing out of control. The configuration option APT::Clean-Installed will prevent installed packages from
           being erased if it is set to off.
```

`clean` is able to remove more.

c.f. also the YouTube video [correct `apt-get` for ubuntu / debian in docker (intermediate) anthony explains](https://youtu.be/ZAoK8O9oBGo)

```
* Use apt-get clean to remove more unneeded package files
   - c.f. https://linux.die.net/man/8/apt-get
```