### PR TITLE
ci: Add Docker image build and publish CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          DOCKER_IMAGE=pyhf/pyhf
+          DOCKER_IMAGE=${{github.repository}}
           VERSION=latest
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
@@ -69,7 +69,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          file: docker/Dockerfile
+          file: Dockerfile
           tags: ${{ steps.prep.outputs.tags }}
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.html_url }}
@@ -91,8 +91,8 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          file: docker/Dockerfile
-          tags: pyhf/pyhf:latest,ghcr.io/${{github.repository}}:latest
+          file: Dockerfile
+          tags: ${{github.repository}}:latest,ghcr.io/${{github.repository}}:latest
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.html_url }}
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}
@@ -105,7 +105,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          file: docker/Dockerfile
+          file: Dockerfile
           tags: ${{ steps.prep.outputs.tags }}
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.html_url }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   docker:
-    name: Build, test, and publish Docker images
+    name: Build and publish Docker images
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,12 +3,12 @@ name: Docker Images
 on:
   push:
     branches:
-    - master
+    - main
     tags:
     - v*
   pull_request:
     branches:
-    - master
+    - main
   schedule:
     - cron:  '1 0 * * *'
   release:
@@ -17,7 +17,7 @@ on:
 
 jobs:
   docker:
-    name: Build, test, and publish Docker images to Docker Hub
+    name: Build, test, and publish Docker images
     runs-on: ubuntu-latest
 
     steps:
@@ -101,8 +101,8 @@ jobs:
           -c "which curl; which tar"
 
       - name: Build and publish to registry
-        # every PR will trigger a push event on master, so check the push event is actually coming from master
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'scikit-hep/pyhf'
+        # every PR will trigger a push event on main, so check the push event is actually coming from main
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'matthewfeickert/pyenv-virtualenv-conda-example'
         id: docker_build_latest
         uses: docker/build-push-action@v2
         with:
@@ -116,7 +116,7 @@ jobs:
           push: true
 
       - name: Build and publish to registry with release tag
-        if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'scikit-hep/pyhf'
+        if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'matthewfeickert/pyenv-virtualenv-conda-example'
         id: docker_build_release
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -84,22 +84,6 @@ jobs:
       - name: List built images
         run: docker images
 
-      - name: Run CLI API check
-        run: |
-          printf "\npyhf\n"
-          docker run --rm pyhf/pyhf:sha-${GITHUB_SHA::8}
-          printf "\npyhf --version\n"
-          docker run --rm pyhf/pyhf:sha-${GITHUB_SHA::8} --version
-          printf "\npyhf --help\n"
-          docker run --rm pyhf/pyhf:sha-${GITHUB_SHA::8} --help
-
-      - name: Check for curl and tar
-        run: >-
-          docker run --rm
-          --entrypoint /bin/bash
-          pyhf/pyhf:sha-${GITHUB_SHA::8}
-          -c "which curl; which tar"
-
       - name: Build and publish to registry
         # every PR will trigger a push event on main, so check the push event is actually coming from main
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'matthewfeickert/pyenv-virtualenv-conda-example'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,130 @@
+name: Docker Images
+
+on:
+  push:
+    branches:
+    - master
+    tags:
+    - v*
+  pull_request:
+    branches:
+    - master
+  schedule:
+    - cron:  '1 0 * * *'
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  docker:
+    name: Build, test, and publish Docker images to Docker Hub
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Prepare
+        id: prep
+        run: |
+          DOCKER_IMAGE=pyhf/pyhf
+          VERSION=latest
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          elif [[ $GITHUB_REF == refs/pull/* ]]; then
+            VERSION=pr-${{ github.event.number }}
+          fi
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          TAGS="$TAGS,${DOCKER_IMAGE}:latest,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
+          # Releases also have GITHUB_REFs that are tags, so reuse VERSION
+          if [ "${{ github.event_name }}" = "release" ]; then
+            TAGS="$TAGS,${DOCKER_IMAGE}:latest-stable,ghcr.io/${{github.repository}}:latest-stable,ghcr.io/${{github.repository}}:${VERSION}"
+          fi
+          echo ::set-output name=version::${VERSION}
+          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Test build
+        id: docker_build_test
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: docker/Dockerfile
+          tags: ${{ steps.prep.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          load: true
+          push: false
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build_test.outputs.digest }}
+
+      - name: List built images
+        run: docker images
+
+      - name: Run CLI API check
+        run: |
+          printf "\npyhf\n"
+          docker run --rm pyhf/pyhf:sha-${GITHUB_SHA::8}
+          printf "\npyhf --version\n"
+          docker run --rm pyhf/pyhf:sha-${GITHUB_SHA::8} --version
+          printf "\npyhf --help\n"
+          docker run --rm pyhf/pyhf:sha-${GITHUB_SHA::8} --help
+
+      - name: Check for curl and tar
+        run: >-
+          docker run --rm
+          --entrypoint /bin/bash
+          pyhf/pyhf:sha-${GITHUB_SHA::8}
+          -c "which curl; which tar"
+
+      - name: Build and publish to registry
+        # every PR will trigger a push event on master, so check the push event is actually coming from master
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'scikit-hep/pyhf'
+        id: docker_build_latest
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: docker/Dockerfile
+          tags: pyhf/pyhf:latest,ghcr.io/${{github.repository}}:latest
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          push: true
+
+      - name: Build and publish to registry with release tag
+        if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'scikit-hep/pyhf'
+        id: docker_build_release
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: docker/Dockerfile
+          tags: ${{ steps.prep.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          push: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,7 +10,7 @@ on:
     branches:
     - main
   schedule:
-    - cron:  '1 0 * * *'
+    - cron:  '1 0 * * 0'
   release:
     types: [published]
   workflow_dispatch:

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN git clone --depth 1 https://github.com/pyenv/pyenv.git ~/.pyenv && \
     popd && \
     echo -e '\nexport PYENV_ROOT="${HOME}/.pyenv"' >> ~/.bash_profile && \
     echo 'export PATH="${PYENV_ROOT}/bin:${PATH}"' >> ~/.bash_profile && \
+    echo 'eval "$(pyenv init --path)"' >> ~/.bash_profile && \
     . ~/.bash_profile && \
     eval "$(pyenv init -)" && \
     git clone --depth 1 https://github.com/pyenv/pyenv-virtualenv.git $(pyenv root)/plugins/pyenv-virtualenv && \


### PR DESCRIPTION
Add a GitHub Actions workflow that builds the Docker image and then deploys it to both Docker Hub and to GitHub Container Registry.

```
* Add CI workflow to build and publish Docker images
   - Publish to both Docker Hub and to GitHub Container Registry
* Fix build by adding evaluation of $(pyenv init --path) to .bash_profile
```