### PR TITLE
fix: Correct Docker Hub repository name

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -92,7 +92,7 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          tags: ${{github.repository}}:latest,ghcr.io/${{github.repository}}:latest
+          tags: matthewfeickert/pyenv-virtualenv-conda:latest,ghcr.io/${{github.repository}}:latest
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.html_url }}
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          DOCKER_IMAGE=${{github.repository}}
+          DOCKER_IMAGE=matthewfeickert/pyenv-virtualenv-conda
           VERSION=latest
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}


### PR DESCRIPTION
The Docker Hub repository name is `matthewfeickert/pyenv-virtualenv-conda` while the ghcr.io name is `matthewfeickert/pyenv-virtualenv-conda-example`.

```
* Correct the Docker Hub repository name
   - matthewfeickert/pyenv-virtualenv-conda-example -> matthewfeickert/pyenv-virtualenv-conda
   - Docker Hub and GitHub Container Registry have different repository names
```