### PR TITLE
feat: Update pyenv to v2.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,14 +53,20 @@ RUN git clone --depth 1 https://github.com/pyenv/pyenv.git \
     popd && \
     sed -i '/^# ~.*/a export PYENV_ROOT="${HOME}/.pyenv"' ~/.profile && \
     sed -i '/^export.*/a export PATH="${PYENV_ROOT}/bin:${PATH}"' ~/.profile && \
-    printf '\neval "$(pyenv init --path)"\n' >> ~/.profile && \
+    sed -i '/^export PATH.*/a \\n# Place pyenv shims on path\nif [[ ":${PATH}:" != *":$(pyenv root)/shims:"* ]]; then\n  eval "$(pyenv init --path)"\nfi' ~/.profile && \
+    printf '\neval "$(pyenv init -)"\n' >> ~/.profile && \
     . ~/.profile && \
-    eval "$(pyenv init --path)" && \
     git clone --depth 1 https://github.com/pyenv/pyenv-virtualenv.git $(pyenv root)/plugins/pyenv-virtualenv && \
-    echo -e '\nif command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init --path)"\n  eval "$(pyenv virtualenv-init -)"\nfi' >> ~/.profile && \
-    echo -e '\nif command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init --path)"\n  eval "$(pyenv virtualenv-init -)"\nfi' >> ~/.bashrc && \
+    printf '# Place pyenv-virtualenv shims on path\nif [[ ":${PATH}:" != *":$(pyenv root)/plugins/pyenv-virtualenv/shims:"* ]]; then\n  eval "$(pyenv virtualenv-init -)"\nfi\n' >> ~/.profile && \
+    printf '\n# Place pyenv shims on path\nif [[ ":${PATH}:" != *":$(pyenv root)/shims:"* ]]; then\n  eval "$(pyenv init --path)"\nfi\n' >> ~/.bashrc && \
+    printf '# Place pyenv-virtualenv shims on path\nif [[ ":${PATH}:" != *":$(pyenv root)/plugins/pyenv-virtualenv/shims:"* ]]; then\n  eval "$(pyenv virtualenv-init -)"\nfi\n' >> ~/.bashrc && \
     cp ~/.profile ~/.bash_profile && \
     sed -i 's/.profile/.bash_profile/' ~/.bash_profile
+
+    # printf 'eval "$(pyenv virtualenv-init -)"\n' >> ~/.bashrc && \
+    # sed -i '/^export PATH.*/a eval "$(pyenv init --path)"\n' ~/.profile && \
+    # echo -e '\nif command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init --path)"\n  eval "$(pyenv virtualenv-init -)"\nfi' >> ~/.profile && \
+    # echo -e '\nif command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init --path)"\n  eval "$(pyenv virtualenv-init -)"\nfi' >> ~/.bashrc && \
 
 # Need to setup shell variables in .bash_profile to use pyenv
 # Install Python 3.8, miniconda, and create virtual environments in both

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN git clone --depth 1 https://github.com/pyenv/pyenv.git \
     printf '\neval "$(pyenv init -)"\n' >> ~/.bashrc && \
     . ~/.profile && \
     git clone --depth 1 https://github.com/pyenv/pyenv-virtualenv.git $(pyenv root)/plugins/pyenv-virtualenv && \
-    printf '# Place pyenv-virtualenv shims on path\nif [[ ":${PATH}:" != *":$(pyenv root)/plugins/pyenv-virtualenv/shims:"* ]]; then\n  eval "$(pyenv virtualenv-init -)"\nfi\n' >> ~/.profile && \
+    printf '\n# Place pyenv-virtualenv shims on path\nif [[ ":${PATH}:" != *":$(pyenv root)/plugins/pyenv-virtualenv/shims:"* ]]; then\n  eval "$(pyenv virtualenv-init -)"\nfi\n' >> ~/.profile && \
     printf '\n# Place pyenv shims on path\nif [[ ":${PATH}:" != *":$(pyenv root)/shims:"* ]]; then\n  eval "$(pyenv init --path)"\nfi\n' >> ~/.bashrc && \
     printf '# Place pyenv-virtualenv shims on path\nif [[ ":${PATH}:" != *":$(pyenv root)/plugins/pyenv-virtualenv/shims:"* ]]; then\n  eval "$(pyenv virtualenv-init -)"\nfi\n' >> ~/.bashrc && \
     cp ~/.profile ~/.bash_profile && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,9 +42,9 @@ ENV HOME /home/docker
 WORKDIR /home/docker
 
 # Install pyenv and pyenv-virtualenv
-ENV PYENV_VERSION=2.0.1
+ENV PYENV_RELEASE_VERSION=2.0.1
 RUN git clone --depth 1 https://github.com/pyenv/pyenv.git \
-        --branch "v${PYENV_VERSION}" \
+        --branch "v${PYENV_RELEASE_VERSION}" \
         --single-branch \
         ~/.pyenv && \
     pushd ~/.pyenv && \
@@ -70,7 +70,7 @@ RUN . "${HOME}/.bash_profile" && \
     pyenv install "${PYTHON_VERSION}" && \
     pyenv virtualenv "${PYTHON_VERSION}" base && \
     pyenv activate base && \
-    python -m pip install --upgrade --no-cache-dir pip setuptools wheel && \
+    python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
     pyenv deactivate && \
     echo "Install miniconda" && \
     pyenv install "${CONDA_VERSION}" && \
@@ -79,7 +79,7 @@ RUN . "${HOME}/.bash_profile" && \
     conda config --set auto_activate_base false && \
     pyenv virtualenv "${CONDA_VERSION}" miniconda3-base && \
     pyenv activate miniconda3-base && \
-    python -m pip install --upgrade --no-cache-dir pip setuptools wheel
+    python -m pip --no-cache-dir install --upgrade pip setuptools wheel
 
 WORKDIR /home/docker/data
 ENTRYPOINT ["/bin/bash", "-l", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN git clone --depth 1 https://github.com/pyenv/pyenv.git \
     sed -i '/^# ~.*/a export PYENV_ROOT="${HOME}/.pyenv"' ~/.profile && \
     sed -i '/^export.*/a export PATH="${PYENV_ROOT}/bin:${PATH}"' ~/.profile && \
     sed -i '/^export PATH.*/a \\n# Place pyenv shims on path\nif [[ ":${PATH}:" != *":$(pyenv root)/shims:"* ]]; then\n  eval "$(pyenv init --path)"\nfi' ~/.profile && \
-    printf '\neval "$(pyenv init -)"\n' >> ~/.profile && \
+    printf '\neval "$(pyenv init -)"\n' >> ~/.bashrc && \
     . ~/.profile && \
     git clone --depth 1 https://github.com/pyenv/pyenv-virtualenv.git $(pyenv root)/plugins/pyenv-virtualenv && \
     printf '# Place pyenv-virtualenv shims on path\nif [[ ":${PATH}:" != *":$(pyenv root)/plugins/pyenv-virtualenv/shims:"* ]]; then\n  eval "$(pyenv virtualenv-init -)"\nfi\n' >> ~/.profile && \
@@ -62,11 +62,6 @@ RUN git clone --depth 1 https://github.com/pyenv/pyenv.git \
     printf '# Place pyenv-virtualenv shims on path\nif [[ ":${PATH}:" != *":$(pyenv root)/plugins/pyenv-virtualenv/shims:"* ]]; then\n  eval "$(pyenv virtualenv-init -)"\nfi\n' >> ~/.bashrc && \
     cp ~/.profile ~/.bash_profile && \
     sed -i 's/.profile/.bash_profile/' ~/.bash_profile
-
-    # printf 'eval "$(pyenv virtualenv-init -)"\n' >> ~/.bashrc && \
-    # sed -i '/^export PATH.*/a eval "$(pyenv init --path)"\n' ~/.profile && \
-    # echo -e '\nif command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init --path)"\n  eval "$(pyenv virtualenv-init -)"\nfi' >> ~/.profile && \
-    # echo -e '\nif command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init --path)"\n  eval "$(pyenv virtualenv-init -)"\nfi' >> ~/.bashrc && \
 
 # Need to setup shell variables in .bash_profile to use pyenv
 # Install Python 3.8, miniconda, and create virtual environments in both

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,10 +57,10 @@ RUN git clone --depth 1 https://github.com/pyenv/pyenv.git \
     . ~/.profile && \
     eval "$(pyenv init --path)" && \
     git clone --depth 1 https://github.com/pyenv/pyenv-virtualenv.git $(pyenv root)/plugins/pyenv-virtualenv && \
-    echo -e '\nif command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\n  eval "$(pyenv virtualenv-init -)"\nfi' >> ~/.profile && \
-    echo -e '\nif command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\n  eval "$(pyenv virtualenv-init -)"\nfi' >> ~/.bashrc && \
+    echo -e '\nif command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init --path)"\n  eval "$(pyenv virtualenv-init -)"\nfi' >> ~/.profile && \
+    echo -e '\nif command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init --path)"\n  eval "$(pyenv virtualenv-init -)"\nfi' >> ~/.bashrc && \
     cp ~/.profile ~/.bash_profile && \
-    sed -i 's/.profile/.bash_profile/g' ~/.bash_profile
+    sed -i 's/.profile/.bash_profile/' ~/.bash_profile
 
 # Need to setup shell variables in .bash_profile to use pyenv
 # Install Python 3.8, miniconda, and create virtual environments in both

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,11 @@ ENV HOME /home/docker
 WORKDIR /home/docker
 
 # Install pyenv and pyenv-virtualenv
-RUN git clone --depth 1 https://github.com/pyenv/pyenv.git ~/.pyenv && \
+ENV PYENV_VERSION=2.0.1
+RUN git clone --depth 1 https://github.com/pyenv/pyenv.git \
+        --branch "v${PYENV_VERSION}" \
+        --single-branch \
+        ~/.pyenv && \
     pushd ~/.pyenv && \
     src/configure && \
     make -C src && \
@@ -59,7 +63,7 @@ RUN git clone --depth 1 https://github.com/pyenv/pyenv.git ~/.pyenv && \
 # Need to setup shell variables in .bash_profile to use pyenv
 # Install Python 3.8, miniconda, and create virtual environments in both
 # c.f. https://stackoverflow.com/a/58045893/8931942
-ENV PYTHON_VERSION 3.8.8
+ENV PYTHON_VERSION=3.8.10
 ENV CONDA_VERSION miniconda3-latest
 RUN . "${HOME}/.bash_profile" && \
     echo "Install Python ${PYTHON_VERSION}" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,14 +51,16 @@ RUN git clone --depth 1 https://github.com/pyenv/pyenv.git \
     src/configure && \
     make -C src && \
     popd && \
-    echo -e '\nexport PYENV_ROOT="${HOME}/.pyenv"' >> ~/.bash_profile && \
-    echo 'export PATH="${PYENV_ROOT}/bin:${PATH}"' >> ~/.bash_profile && \
-    echo 'eval "$(pyenv init --path)"' >> ~/.bash_profile && \
-    . ~/.bash_profile && \
+    sed -i '/^# ~.*/a export PYENV_ROOT="${HOME}/.pyenv"' ~/.profile && \
+    sed -i '/^export.*/a export PATH="${PYENV_ROOT}/bin:${PATH}"' ~/.profile && \
+    printf '\neval "$(pyenv init --path)"\n' >> ~/.profile && \
+    . ~/.profile && \
     eval "$(pyenv init -)" && \
     git clone --depth 1 https://github.com/pyenv/pyenv-virtualenv.git $(pyenv root)/plugins/pyenv-virtualenv && \
-    echo -e '\nif command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\n  eval "$(pyenv virtualenv-init -)"\nfi' >> ~/.bash_profile && \
-    echo -e '\nif command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\n  eval "$(pyenv virtualenv-init -)"\nfi' >> ~/.bashrc
+    echo -e '\nif command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\n  eval "$(pyenv virtualenv-init -)"\nfi' >> ~/.profile && \
+    echo -e '\nif command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\n  eval "$(pyenv virtualenv-init -)"\nfi' >> ~/.bashrc && \
+    cp ~/.profile ~/.bash_profile && \
+    sed -i 's/.profile/.bash_profile/g' ~/.bash_profile
 
 # Need to setup shell variables in .bash_profile to use pyenv
 # Install Python 3.8, miniconda, and create virtual environments in both

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN git clone --depth 1 https://github.com/pyenv/pyenv.git \
     sed -i '/^export.*/a export PATH="${PYENV_ROOT}/bin:${PATH}"' ~/.profile && \
     printf '\neval "$(pyenv init --path)"\n' >> ~/.profile && \
     . ~/.profile && \
-    eval "$(pyenv init -)" && \
+    eval "$(pyenv init --path)" && \
     git clone --depth 1 https://github.com/pyenv/pyenv-virtualenv.git $(pyenv root)/plugins/pyenv-virtualenv && \
     echo -e '\nif command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\n  eval "$(pyenv virtualenv-init -)"\nfi' >> ~/.profile && \
     echo -e '\nif command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\n  eval "$(pyenv virtualenv-init -)"\nfi' >> ~/.bashrc && \

--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,14 @@ default: image
 all: image
 
 image:
+	docker pull debian:buster
 	docker build . \
-	--pull \
 	--file Dockerfile \
 	-t matthewfeickert/pyenv-virtualenv-conda:latest \
 	--compress
 
 test:
+	docker pull debian:buster
 	docker build . \
-	--pull \
 	--file Dockerfile \
 	-t matthewfeickert/pyenv-virtualenv-conda:debug-local


### PR DESCRIPTION
Resolves #6 

```
* Checkout release v2.0.1 of pyenv
* Set all configuration in .profile and then copy to .bash_profile
* Add Bash logic guards to avoid redundant additions of shims to PATH for pyenv and pyenv-virtualenv
   - Add guards to both .profile and .bashrc
* Add `pyenv init -` eval to .bashrc
* Update to Python v3.8.10
```